### PR TITLE
Feature/adding dash page

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -1,4 +1,5 @@
 import zerorpc
+import sys
 
 
 class TestApi():
@@ -7,10 +8,13 @@ class TestApi():
         return text
 
 
-
-
-port = "1234"
+port = "18018"
 addr = "tcp://127.0.0.1:" + port
+
+
+if len(sys.argv) > 1:
+    port = sys.argv[1]
+
 
 s = zerorpc.Server(TestApi())
 s.bind(addr)

--- a/dash/page.py
+++ b/dash/page.py
@@ -6,6 +6,8 @@ import plotly.express as px
 
 import pandas as pd
 
+import sys
+
 df = pd.read_csv('https://raw.githubusercontent.com/plotly/datasets/master/gapminderDataFiveYear.csv')
 
 app = Dash(__name__)
@@ -35,5 +37,10 @@ def update_figure(selected_year):
 
     return fig
 
+port = "18019"
 
-app.run_server(port=1235, debug=True)
+
+if len(sys.argv) > 1:
+    port = sys.argv[1]
+
+app.run_server(port=port, debug=True)

--- a/dash/page.py
+++ b/dash/page.py
@@ -7,6 +7,15 @@ import plotly.express as px
 import pandas as pd
 
 import sys
+import signal
+
+# Define the exit behaviour of Dash
+# Normally SIGINT would leave an orphaned Flask process running
+def termination_handler(sig, frame):
+    print("SIGINT received: terminating Flask server.")
+    sys.exit(0)
+
+signal.signal(signal.SIGINT, termination_handler)
 
 df = pd.read_csv('https://raw.githubusercontent.com/plotly/datasets/master/gapminderDataFiveYear.csv')
 

--- a/dash/page.py
+++ b/dash/page.py
@@ -1,0 +1,39 @@
+# See official docs at https://dash.plotly.com
+# pip install dash pandas
+
+from dash import Dash, dcc, html, Input, Output
+import plotly.express as px
+
+import pandas as pd
+
+df = pd.read_csv('https://raw.githubusercontent.com/plotly/datasets/master/gapminderDataFiveYear.csv')
+
+app = Dash(__name__)
+
+app.layout = html.Div([
+    dcc.Graph(id='graph-with-slider'),
+    dcc.Slider(
+        df['year'].min(),
+        df['year'].max(),
+        step=None,
+        value=df['year'].min(),
+        marks={str(year): str(year) for year in df['year'].unique()},
+        id='year-slider'
+    )
+])
+
+
+@app.callback(
+    Output('graph-with-slider', 'figure'),
+    Input('year-slider', 'value'))
+def update_figure(selected_year):
+    filtered_df = df[df.year == selected_year]
+
+    fig = px.scatter(filtered_df, x="gdpPercap", y="lifeExp",
+                     size="pop", color="continent", hover_name="country",
+                     log_x=True, size_max=55)
+
+    return fig
+
+
+app.run_server(port=1235, debug=True)

--- a/main.js
+++ b/main.js
@@ -10,7 +10,8 @@ const path = require('node:path')
 //  Defines the path to the Python api file
 const API = './api/api'
 const DASH = './dash/page'
-const PORT = 18018
+const API_PORT = 18018
+const DASH_PORT = 18019
 
 let pyProc = null
 let dashProc = null
@@ -68,14 +69,14 @@ const createPyProc = () => {
     
     // if we are building the package, use the bin
     if(buildPackage()){
-        pyProc = require("child_process").execFile(api_path, [PORT])
+        pyProc = require("child_process").execFile(api_path, [API_PORT])
     }
     else{
-        pyProc = require("child_process").spawn("python", [api_path, PORT])
+        pyProc = require("child_process").spawn("python", [api_path, API_PORT])
     }
 
     if(pyProc != null) {
-        console.log('child process success on port ' + PORT)
+        console.log('child process success on port ' + API_PORT)
     }
 }
 
@@ -93,7 +94,7 @@ const createDashProc = () => {
 
     dashPath = getDashPath()
 
-    dashProc = require("child_process").spawn("python", [dashPath])
+    dashProc = require("child_process").spawn("python", [dashPath, DASH_PORT])
 
     if(dashProc != null) {
         console.log('dash process success')
@@ -128,7 +129,7 @@ function createWindow () {
 
     // and load the index.html of the app.
     //mainWindow.loadFile('index.html')
-    mainWindow.loadURL('http://127.0.0.1:1235/')
+    mainWindow.loadURL('http://127.0.0.1:' + DASH_PORT)
 
 
     // Open the DevTools.

--- a/main.js
+++ b/main.js
@@ -9,9 +9,11 @@ const path = require('node:path')
 
 //  Defines the path to the Python api file
 const API = './api/api'
+const DASH = './dash/page'
 const PORT = 18018
 
 let pyProc = null
+let dashProc = null
 
 /**
  *  Checks to see if the binary has been built for the API,
@@ -20,7 +22,7 @@ let pyProc = null
  * @returns boolean
  */
 const buildPackage = () => {
-    
+
     api_path = path.join(__dirname, API)
     
     return require('fs').existsSync(api_path)
@@ -42,6 +44,17 @@ const getApiPath = () => {
     }
     else{
         return path.join(__dirname, API + ".py")
+    }
+}
+
+
+const getDashPath = () => {
+
+    if(buildPackage()){
+        return path.join(__dirname, DASH)
+    }
+    else{
+        return path.join(__dirname, DASH + ".py")
     }
 }
 
@@ -71,8 +84,35 @@ const exitPyProc = () => {
     pyProc = null
 }
 
+
+/**
+ *  Creates the Dash process
+ */
+
+const createDashProc = () => {
+
+    dashPath = getDashPath()
+
+    dashProc = require("child_process").spawn("python", [dashPath])
+
+    if(dashProc != null) {
+        console.log('dash process success')
+    }
+    
+}
+
+const exitDashProc = () => {
+    dashProc.kill()
+    dashProc = null
+}
+
+
+
+
 app.on('ready', createPyProc)
+app.on('ready', createDashProc)
 app.on('will-quit', exitPyProc)
+app.on('will-quit', exitDashProc)
 
 
 
@@ -87,7 +127,9 @@ function createWindow () {
     })
 
     // and load the index.html of the app.
-    mainWindow.loadFile('index.html')
+    //mainWindow.loadFile('index.html')
+    mainWindow.loadURL('http://127.0.0.1:1235/')
+
 
     // Open the DevTools.
     // mainWindow.webContents.openDevTools()

--- a/main.js
+++ b/main.js
@@ -24,9 +24,9 @@ let dashProc = null
  */
 const buildPackage = () => {
 
-    api_path = path.join(__dirname, API)
-    
-    return require('fs').existsSync(api_path)
+    dependency_path = path.join(__dirname, API)
+
+    return require('fs').existsSync(dependency_path)
 }
 
 /**
@@ -66,13 +66,13 @@ const getDashPath = () => {
 const createPyProc = () => {
     
     api_path = getApiPath()
-    
+
     // if we are building the package, use the bin
     if(buildPackage()){
         pyProc = require("child_process").execFile(api_path, [API_PORT])
     }
     else{
-        pyProc = require("child_process").spawn("python", [api_path, API_PORT])
+        pyProc = require("child_process").spawn("python", [api_path, API_PORT], {stdio: "inherit"})
     }
 
     if(pyProc != null) {
@@ -81,7 +81,7 @@ const createPyProc = () => {
 }
 
 const exitPyProc = () => {
-    pyProc.kill()
+    pyProc.kill("SIGINT")
     pyProc = null
 }
 
@@ -94,7 +94,7 @@ const createDashProc = () => {
 
     dashPath = getDashPath()
 
-    dashProc = require("child_process").spawn("python", [dashPath, DASH_PORT])
+    dashProc = require("child_process").spawn("python", [dashPath, DASH_PORT], {stdio: "inherit"})
 
     if(dashProc != null) {
         console.log('dash process success')
@@ -103,17 +103,14 @@ const createDashProc = () => {
 }
 
 const exitDashProc = () => {
-    dashProc.kill()
+    dashProc.kill("SIGINT")
     dashProc = null
 }
 
-
-
-
 app.on('ready', createPyProc)
 app.on('ready', createDashProc)
-app.on('will-quit', exitPyProc)
-app.on('will-quit', exitDashProc)
+app.on('before-quit', exitPyProc)
+//app.on('before-quit', exitDashProc)
 
 
 
@@ -131,7 +128,7 @@ function createWindow () {
     //mainWindow.loadFile('index.html')
     mainWindow.loadURL('http://127.0.0.1:' + DASH_PORT)
 
-
+    
     // Open the DevTools.
     // mainWindow.webContents.openDevTools()
 }


### PR DESCRIPTION
Added dash.py
- Starts the Flask server for dash
- Includes boilerplate code for running the dash server

Main.js
- Default connection is to dash server local URL

ONGOING BUGS: 
When force-quitting out of the Electron app, the dash server is not killed. Only after control-C in the Electron app terminal does the Flask process get killed.