### PR TITLE
Sidebar features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules*
 package-lock*
 
 **/__pycache__/
+.DS_Store

--- a/api/page.py
+++ b/api/page.py
@@ -23,23 +23,26 @@ app.layout = dbc.Container(
                     [
                     dbc.Col(
                         html.Div(
-                            id = "filters-sidebare",
+                            id = "filters-sidebar",
                             style = {
                                 "backgroundColor": "lightGrey",
                                 "padding": "5px",
-                                "position": "fixed"
+                                "width": "inherit",
+                                "position": "fixed",
+                                "top": 0,
+                                "bottom": 0,
+                                "overflow-y": "scroll"
                             },
                             children = [
                                 html.H1("Filters"),
                                 html.Div(
-                                    
                                     dbc.Accordion(
                                         [
                                             dbc.AccordionItem(
                                                 [
                                                     # Have to go back and put in actual values used in DB
                                                     # Format Label:Value
-                                                    html.H2("Drainage"),
+                                                    html.H3("Drainage"),
                                                     dcc.Checklist(
                                                         options={
                                                             "Drained":"Drained", 
@@ -48,7 +51,7 @@ app.layout = dbc.Container(
                                                         id="drainage_checklist",
                                                         inline=True
                                                     ),
-                                                    html.H2("Shearing"),
+                                                    html.H3("Shearing"),
                                                     dcc.Checklist(
                                                         options={
                                                             "Compression":"Compression", 
@@ -57,7 +60,7 @@ app.layout = dbc.Container(
                                                         id="shearing_checklist",
                                                         inline=True
                                                     ),
-                                                    html.H2("Anisotropy"),
+                                                    html.H3("Anisotropy"),
                                                     dcc.Checklist(
                                                         options={
                                                             "Isotropic":"Isotropic", 
@@ -79,7 +82,7 @@ app.layout = dbc.Container(
                                                     "Max Value:",
                                                     dcc.Input(id="anisotropy_max_value", type="number", min=0, max=1.0, value=0, style={'width': '80px'}),
                                                     
-                                                    html.H2("Consolidation"),
+                                                    html.H3("Consolidation"),
                                                     html.P(id="consolidation_value"),
                                                     dcc.RangeSlider(
                                                         10,
@@ -102,7 +105,7 @@ app.layout = dbc.Container(
                                                     "Max Value:",
                                                     dcc.Input(id="consolidation_max_value", type="number", min=0, max=1500, value=0, style={'width': '80px'}),
 
-                                                    html.H2("Availability"),
+                                                    html.H3("Availability"),
                                                     dcc.Checklist(
                                                         options={
                                                             "Public":"Public", 
@@ -116,7 +119,7 @@ app.layout = dbc.Container(
                                             ),
                                             dbc.AccordionItem(
                                                 [
-                                                    html.H2("Density"),
+                                                    html.H3("Density"),
                                                     dcc.Checklist(
                                                         options={
                                                             "Loose":"Loose",
@@ -125,7 +128,7 @@ app.layout = dbc.Container(
                                                         id="density_checklist",
                                                         inline=True
                                                     ),
-                                                    html.H2("Plasticity"),
+                                                    html.H3("Plasticity"),
                                                     dcc.Checklist(
                                                         options={
                                                             "Plastic":"Plastic",
@@ -135,7 +138,7 @@ app.layout = dbc.Container(
                                                         id="plasticity_checklist",
                                                         inline=True
                                                     ),
-                                                    html.H2("PSD"),
+                                                    html.H3("PSD"),
                                                     dcc.Checklist(
                                                         options={
                                                             "Clay":"Clay",
@@ -150,7 +153,7 @@ app.layout = dbc.Container(
                                             ),
                                             dbc.AccordionItem(
                                                 [
-                                                    html.H2("Axial Strain Filter"),
+                                                    html.H3("Axial Strain Filter"),
                                                     html.P(id="axial_value"),
                                                     dcc.RangeSlider(
                                                         0,
@@ -172,7 +175,7 @@ app.layout = dbc.Container(
                                                     "Max Value:",
                                                     dcc.Input(id="axial_max_value", type="number", min=0, max=0.5, value=0, style={'width': '80px'}),
                                                     
-                                                    html.H2("p' Filter"),
+                                                    html.H3("p' Filter"),
                                                     html.P(id="p_value"),
                                                     dcc.RangeSlider(
                                                         0,
@@ -181,7 +184,7 @@ app.layout = dbc.Container(
                                                         value=[0,500], 
                                                         id='p_slider'
                                                     ), 
-                                                    html.H2("Induced PWP Filter"),
+                                                    html.H3("Induced PWP Filter"),
                                                     html.P(id="pwp_value"),
                                                     dcc.RangeSlider(
                                                         0,
@@ -190,7 +193,7 @@ app.layout = dbc.Container(
                                                         value=[0,500], 
                                                         id='pwp_slider'
                                                     ),
-                                                    html.H2("Deviator stress (q) Filter"),
+                                                    html.H3("Deviator stress (q) Filter"),
                                                     html.P(id="q_value"),
                                                     dcc.RangeSlider(
                                                         0,
@@ -200,7 +203,7 @@ app.layout = dbc.Container(
                                                         id='q_slider'
                                                     ),
 
-                                                    html.H2("Void Ratio (e) Filter"),
+                                                    html.H3("Void Ratio (e) Filter"),
                                                     html.P(id="e_value"),
                                                     dcc.RangeSlider(
                                                         0,
@@ -224,7 +227,6 @@ app.layout = dbc.Container(
                                         always_open=True, flush=True,
                                     )
                                 ),
-                                
                             ]
                         ), 
                         width=3

--- a/api/page.py
+++ b/api/page.py
@@ -78,9 +78,9 @@ app.layout = dbc.Container(
                                                         tooltip={"placement": "bottom", "always_visible": True}
                                                     ),
                                                     "Min Value:",
-                                                    dcc.Input(id="anisotropy_min_value", type="number", min=0, max=1.0, value=1.0, style={'width': '80px'}),
+                                                    dcc.Input(id="anisotropy_min_value", type="number", min=0, max=1.0, value=1.0,  step=0.05, style={'width': '70px'}),
                                                     "Max Value:",
-                                                    dcc.Input(id="anisotropy_max_value", type="number", min=0, max=1.0, value=0, style={'width': '80px'}),
+                                                    dcc.Input(id="anisotropy_max_value", type="number", min=0, max=1.0, value=0,  step=0.05, style={'width': '70px'}),
                                                     
                                                     html.H3("Consolidation"),
                                                     html.P(id="consolidation_value"),
@@ -101,9 +101,9 @@ app.layout = dbc.Container(
                                                         tooltip={"placement": "bottom", "always_visible": True}
                                                     ),
                                                     "Min Value:",
-                                                    dcc.Input(id="consolidation_min_value", type="number", min=0, max=1500, value=1500, style={'width': '80px'}),
+                                                    dcc.Input(id="consolidation_min_value", type="number", min=0, max=1500, value=1500, style={'width': '70px'}),
                                                     "Max Value:",
-                                                    dcc.Input(id="consolidation_max_value", type="number", min=0, max=1500, value=0, style={'width': '80px'}),
+                                                    dcc.Input(id="consolidation_max_value", type="number", min=0, max=1500, value=0, style={'width': '70px'}),
 
                                                     html.H3("Availability"),
                                                     dcc.Checklist(
@@ -168,12 +168,13 @@ app.layout = dbc.Container(
                                                             0.5: "0.5"
                                                         },
                                                         value=[0,0.5], 
-                                                        id='axial_slider'
+                                                        id='axial_slider',
+                                                        tooltip={"placement": "bottom", "always_visible": True}
                                                     ),
                                                     "Min Value:",
-                                                    dcc.Input(id="axial_min_value", type="number", min=0, max=0.5, value=0.5, style={'width': '80px'}),
+                                                    dcc.Input(id="axial_min_value", type="number", min=0, max=0.5, value=0, step=0.05, style={'width': '70px'}),
                                                     "Max Value:",
-                                                    dcc.Input(id="axial_max_value", type="number", min=0, max=0.5, value=0, style={'width': '80px'}),
+                                                    dcc.Input(id="axial_max_value", type="number", min=0, max=0.5, value=0.5, step=0.05, style={'width': '70px'}),
                                                     
                                                     html.H3("p' Filter"),
                                                     html.P(id="p_value"),
@@ -182,8 +183,14 @@ app.layout = dbc.Container(
                                                         500,
                                                         step=None,
                                                         value=[0,500], 
-                                                        id='p_slider'
+                                                        id='p_slider',
+                                                        tooltip={"placement": "bottom", "always_visible": True}
                                                     ), 
+                                                    "Min Value:",
+                                                    dcc.Input(id="p_min_value", type="number", min=0, max=500, value=0, style={'width': '70px'}),
+                                                    "Max Value:",
+                                                    dcc.Input(id="p_max_value", type="number", min=0, max=500, value=500, style={'width': '70px'}),
+
                                                     html.H3("Induced PWP Filter"),
                                                     html.P(id="pwp_value"),
                                                     dcc.RangeSlider(
@@ -191,8 +198,14 @@ app.layout = dbc.Container(
                                                         500,
                                                         step=None,
                                                         value=[0,500], 
-                                                        id='pwp_slider'
+                                                        id='pwp_slider',
+                                                        tooltip={"placement": "bottom", "always_visible": True}
                                                     ),
+                                                    "Min Value:",
+                                                    dcc.Input(id="pwp_min_value", type="number", min=0, max=500, value=0, style={'width': '70px'}),
+                                                    "Max Value:",
+                                                    dcc.Input(id="pwp_max_value", type="number", min=0, max=500, value=500, style={'width': '70px'}),
+                                                    
                                                     html.H3("Deviator stress (q) Filter"),
                                                     html.P(id="q_value"),
                                                     dcc.RangeSlider(
@@ -200,9 +213,14 @@ app.layout = dbc.Container(
                                                         500,
                                                         step=None,
                                                         value=[0,500], 
-                                                        id='q_slider'
+                                                        id='q_slider',
+                                                        tooltip={"placement": "bottom", "always_visible": True}
                                                     ),
-
+                                                    "Min Value:",
+                                                    dcc.Input(id="q_min_value", type="number", min=0, max=500, value=0, style={'width': '70px'}),
+                                                    "Max Value:",
+                                                    dcc.Input(id="q_max_value", type="number", min=0, max=500, value=500, style={'width': '70px'}),
+                                                    
                                                     html.H3("Void Ratio (e) Filter"),
                                                     html.P(id="e_value"),
                                                     dcc.RangeSlider(
@@ -218,8 +236,14 @@ app.layout = dbc.Container(
                                                             1.0: "1.0"
                                                         },
                                                         value=[0,1], 
-                                                        id='e_slider'
+                                                        id='e_slider',
+                                                        tooltip={"placement": "bottom", "always_visible": True}
                                                     ),
+                                                    "Min Value:",
+                                                    dcc.Input(id="e_min_value", type="number", min=0, max=1, value=0, step=0.1, style={'width': '70px'}),
+                                                    "Max Value:",
+                                                    dcc.Input(id="e_max_value", type="number", min=0, max=1, value=1, step=0.1, style={'width': '70px'}),
+                                                                                                        
                                                     ],
                                                 title="Variables",
                                             ),
@@ -252,68 +276,36 @@ app.layout = dbc.Container(
     fluid=True,
 )
 
-@app.callback(
+def sync_slider_callback(min_id, max_id, slider):
+    @app.callback(
     [
-    Output("consolidation_min_value","value"),
-    Output("consolidation_max_value","value"),
-    Output("consolidation_slider","value")    
+    Output(min_id,"value"),
+    Output(max_id,"value"),
+    Output(slider,"value")    
     ],    
     [
-     Input("consolidation_min_value","value"),
-     Input("consolidation_max_value","value"),
-     Input("consolidation_slider","value")
+     Input(min_id,"value"),
+     Input(max_id,"value"),
+     Input(slider,"value")
     ]   
 )
-def sync_consol_slider(start, end, slider):
-    trigger_id = ctx.triggered_id
+    def sync_slider(start, end, slider):
+        trigger_id = ctx.triggered_id
 
-    consolidation_min_value = start if trigger_id == "consolidation_min_value" else slider[0]
-    consolidation_max_value = end if trigger_id == "consolidation_max_value" else slider[1]
-    consolidation_slider_value = slider if trigger_id == "consolidation_slider" else [consolidation_min_value, consolidation_max_value]
+        min_value = start if trigger_id == min_id else slider[0]
+        max_value = end if trigger_id == max_id else slider[1]
+        slider_value = slider if trigger_id == slider else [min_value, max_value]
 
-    return consolidation_min_value, consolidation_max_value, consolidation_slider_value
+        return min_value, max_value, slider_value
 
-@app.callback(
-    [
-    Output("anisotropy_min_value","value"),
-    Output("anisotropy_max_value","value"),
-    Output("anisotropy_slider","value")    
-    ],    
-    [
-     Input("anisotropy_min_value","value"),
-     Input("anisotropy_max_value","value"),
-     Input("anisotropy_slider","value")
-    ]   
-)
-def sync_aniso_slider(start, end, slider):
-    trigger_id = ctx.triggered_id
+sync_slider_callback("consolidation_min_value", "consolidation_max_value", "consolidation_slider")
+sync_slider_callback("anisotropy_min_value", "anisotropy_max_value", "anisotropy_slider")
+sync_slider_callback("axial_min_value", "axial_max_value", "axial_slider")    
+sync_slider_callback("p_min_value", "p_max_value", "p_slider")
+sync_slider_callback("pwp_min_value", "pwp_max_value", "pwp_slider")
+sync_slider_callback("q_min_value", "q_max_value", "q_slider")
+sync_slider_callback("e_min_value", "e_max_value", "e_slider")
 
-    anisotropy_min_value = start if trigger_id == "anisotropy_min_value" else slider[0]
-    anisotropy_max_value = end if trigger_id == "anisotropy_max_value" else slider[1]
-    anisotropy_slider_value = slider if trigger_id == "anisotropy_slider" else [anisotropy_min_value, anisotropy_max_value]
-
-    return anisotropy_min_value, anisotropy_max_value, anisotropy_slider_value
-
-@app.callback(
-    [
-    Output("axial_min_value","value"),
-    Output("axial_max_value","value"),
-    Output("axial_slider","value")    
-    ],    
-    [
-     Input("axial_min_value","value"),
-     Input("axial_max_value","value"),
-     Input("axial_slider","value")
-    ]   
-)
-def sync_axial_slider(start, end, slider):
-    trigger_id = ctx.triggered_id
-
-    axial_min_value = start if trigger_id == "axial_min_value" else slider[0]
-    axial_max_value = end if trigger_id == "axial_max_value" else slider[1]
-    axial_slider_value = slider if trigger_id == "axial_slider" else [axial_min_value, axial_max_value]
-
-    return axial_min_value, axial_max_value, axial_slider_value
 
 @app.callback(
     [

--- a/api/page.py
+++ b/api/page.py
@@ -14,227 +14,240 @@ app = Dash(__name__)
 df_combined = retrieve_entry_data()
 #print(df_combined)
 
-app.layout = html.Div(
-    id = "app-container",
-    style = {
-        "display": "flex",
-        "margin": "5px"},
-    children = [   
+app.layout = dbc.Container(
+    children = [
         html.Div(
-            id = "filters",
-            style = {
-                "backgroundColor": "lightGrey",
-                "padding": "5px",
-                "float": "left"
-            },
-            children = [
-                html.Div(
-                    dbc.Accordion(
-                        [
-                            dbc.AccordionItem(
-                                [
-                                    # Have to go back and put in actual values used in DB
-                                    # Format Label:Value
-                                    html.H2("Drainage"),
-                                    dcc.Checklist(
-                                        options={
-                                            "Drained":"Drained", 
-                                            "Undrained":"Undrained"},
-                                        value=["Drained", "Undrained"],
-                                        id="drainage_checklist",
-                                        inline=True
-                                    ),
-                                    html.H2("Shearing"),
-                                    dcc.Checklist(
-                                        options={
-                                            "Compression":"Compression", 
-                                            "Extension":"Extension"},
-                                        value=["Compression", "Extension"],
-                                        id="shearing_checklist",
-                                        inline=True
-                                    ),
-                                    html.H2("Anisotropy"),
-                                    dcc.Checklist(
-                                        options={
-                                            "Isotropic":"Isotropic", 
-                                            "Anisotropic":"Anisotropic"},
-                                        value=["Isotropic", "Anisotropic"],
-                                        id="anisotropy_checklist",
-                                        inline=True
-                                    ),
-                                    dcc.RangeSlider(
-                                        0.3,
-                                        1,
-                                        step=None,
-                                        value=[0.3,1.0], 
-                                        id="anisotropy_slider",
-                                        tooltip={"placement": "bottom", "always_visible": True}
-                                    ),
-                                    "Min Value:",
-                                    dcc.Input(id="anisotropy_min_value", type="number", min=0, max=1.0, value=1.0, style={'width': '80px'}),
-                                    "Max Value:",
-                                    dcc.Input(id="anisotropy_max_value", type="number", min=0, max=1.0, value=0, style={'width': '80px'}),
+            id = "app-container",
+            children = [  
+                dbc.Row( 
+                    [
+                    dbc.Col(
+                        html.Div(
+                            id = "filters-sidebare",
+                            style = {
+                                "backgroundColor": "lightGrey",
+                                "padding": "5px",
+                                "position": "fixed"
+                            },
+                            children = [
+                                html.H1("Filters"),
+                                html.Div(
                                     
-                                    html.H2("Consolidation"),
-                                    html.P(id="consolidation_value"),
-                                    dcc.RangeSlider(
-                                        10,
-                                        1500,
-                                        step=1,
-                                        marks={
-                                            10: "10",
-                                            300: "300",
-                                            600: "600",
-                                            900: "900",
-                                            1200: "1200",
-                                            1500: "1500"
-                                        },
-                                        value=[10,1500], 
-                                        id="consolidation_slider",
-                                        tooltip={"placement": "bottom", "always_visible": True}
-                                    ),
-                                    "Min Value:",
-                                    dcc.Input(id="consolidation_min_value", type="number", min=0, max=1500, value=1500, style={'width': '80px'}),
-                                    "Max Value:",
-                                    dcc.Input(id="consolidation_max_value", type="number", min=0, max=1500, value=0, style={'width': '80px'}),
+                                    dbc.Accordion(
+                                        [
+                                            dbc.AccordionItem(
+                                                [
+                                                    # Have to go back and put in actual values used in DB
+                                                    # Format Label:Value
+                                                    html.H2("Drainage"),
+                                                    dcc.Checklist(
+                                                        options={
+                                                            "Drained":"Drained", 
+                                                            "Undrained":"Undrained"},
+                                                        value=["Drained", "Undrained"],
+                                                        id="drainage_checklist",
+                                                        inline=True
+                                                    ),
+                                                    html.H2("Shearing"),
+                                                    dcc.Checklist(
+                                                        options={
+                                                            "Compression":"Compression", 
+                                                            "Extension":"Extension"},
+                                                        value=["Compression", "Extension"],
+                                                        id="shearing_checklist",
+                                                        inline=True
+                                                    ),
+                                                    html.H2("Anisotropy"),
+                                                    dcc.Checklist(
+                                                        options={
+                                                            "Isotropic":"Isotropic", 
+                                                            "Anisotropic":"Anisotropic"},
+                                                        value=["Isotropic", "Anisotropic"],
+                                                        id="anisotropy_checklist",
+                                                        inline=True
+                                                    ),
+                                                    dcc.RangeSlider(
+                                                        0.3,
+                                                        1,
+                                                        step=None,
+                                                        value=[0.3,1.0], 
+                                                        id="anisotropy_slider",
+                                                        tooltip={"placement": "bottom", "always_visible": True}
+                                                    ),
+                                                    "Min Value:",
+                                                    dcc.Input(id="anisotropy_min_value", type="number", min=0, max=1.0, value=1.0, style={'width': '80px'}),
+                                                    "Max Value:",
+                                                    dcc.Input(id="anisotropy_max_value", type="number", min=0, max=1.0, value=0, style={'width': '80px'}),
+                                                    
+                                                    html.H2("Consolidation"),
+                                                    html.P(id="consolidation_value"),
+                                                    dcc.RangeSlider(
+                                                        10,
+                                                        1500,
+                                                        step=1,
+                                                        marks={
+                                                            10: "10",
+                                                            300: "300",
+                                                            600: "600",
+                                                            900: "900",
+                                                            1200: "1200",
+                                                            1500: "1500"
+                                                        },
+                                                        value=[10,1500], 
+                                                        id="consolidation_slider",
+                                                        tooltip={"placement": "bottom", "always_visible": True}
+                                                    ),
+                                                    "Min Value:",
+                                                    dcc.Input(id="consolidation_min_value", type="number", min=0, max=1500, value=1500, style={'width': '80px'}),
+                                                    "Max Value:",
+                                                    dcc.Input(id="consolidation_max_value", type="number", min=0, max=1500, value=0, style={'width': '80px'}),
 
-                                    html.H2("Availability"),
-                                    dcc.Checklist(
-                                        options={
-                                            "Public":"Public", 
-                                            "Confidential":"Confidential"},
-                                        value=["Public", "Confidential"],
-                                        id="availability_checklist",
-                                        inline=True
+                                                    html.H2("Availability"),
+                                                    dcc.Checklist(
+                                                        options={
+                                                            "Public":"Public", 
+                                                            "Confidential":"Confidential"},
+                                                        value=["Public", "Confidential"],
+                                                        id="availability_checklist",
+                                                        inline=True
+                                                    )
+                                                ],
+                                                title="Test",
+                                            ),
+                                            dbc.AccordionItem(
+                                                [
+                                                    html.H2("Density"),
+                                                    dcc.Checklist(
+                                                        options={
+                                                            "Loose":"Loose",
+                                                            "Dense":"Dense"},
+                                                        value=["Loose", "Dense"],
+                                                        id="density_checklist",
+                                                        inline=True
+                                                    ),
+                                                    html.H2("Plasticity"),
+                                                    dcc.Checklist(
+                                                        options={
+                                                            "Plastic":"Plastic",
+                                                            "Non-plastic":"Nonplastic",
+                                                            "Unknown":"Unknown"},
+                                                        value=["Plastic", "Non-plastic","Unknown"],
+                                                        id="plasticity_checklist",
+                                                        inline=True
+                                                    ),
+                                                    html.H2("PSD"),
+                                                    dcc.Checklist(
+                                                        options={
+                                                            "Clay":"Clay",
+                                                            "Sand":"Sand",
+                                                            "Silt":"Silt"},
+                                                        value=["Clay", "Sand","Silt"],
+                                                        id="psd_checklist",
+                                                        inline=True
+                                                    ),
+                                                ],
+                                                title="Sample",
+                                            ),
+                                            dbc.AccordionItem(
+                                                [
+                                                    html.H2("Axial Strain Filter"),
+                                                    html.P(id="axial_value"),
+                                                    dcc.RangeSlider(
+                                                        0,
+                                                        0.5,
+                                                        step=0.05,
+                                                        marks={
+                                                            0.0: "0.0",
+                                                            0.1: "0.1",
+                                                            0.2: "0.2",
+                                                            0.3: "0.3",
+                                                            0.4: "0.4",
+                                                            0.5: "0.5"
+                                                        },
+                                                        value=[0,0.5], 
+                                                        id='axial_slider'
+                                                    ),
+                                                    "Min Value:",
+                                                    dcc.Input(id="axial_min_value", type="number", min=0, max=0.5, value=0.5, style={'width': '80px'}),
+                                                    "Max Value:",
+                                                    dcc.Input(id="axial_max_value", type="number", min=0, max=0.5, value=0, style={'width': '80px'}),
+                                                    
+                                                    html.H2("p' Filter"),
+                                                    html.P(id="p_value"),
+                                                    dcc.RangeSlider(
+                                                        0,
+                                                        500,
+                                                        step=None,
+                                                        value=[0,500], 
+                                                        id='p_slider'
+                                                    ), 
+                                                    html.H2("Induced PWP Filter"),
+                                                    html.P(id="pwp_value"),
+                                                    dcc.RangeSlider(
+                                                        0,
+                                                        500,
+                                                        step=None,
+                                                        value=[0,500], 
+                                                        id='pwp_slider'
+                                                    ),
+                                                    html.H2("Deviator stress (q) Filter"),
+                                                    html.P(id="q_value"),
+                                                    dcc.RangeSlider(
+                                                        0,
+                                                        500,
+                                                        step=None,
+                                                        value=[0,500], 
+                                                        id='q_slider'
+                                                    ),
+
+                                                    html.H2("Void Ratio (e) Filter"),
+                                                    html.P(id="e_value"),
+                                                    dcc.RangeSlider(
+                                                        0,
+                                                        1,
+                                                        step=0.01,
+                                                        marks={
+                                                            0.0: "0.0",
+                                                            0.2: "0.2",
+                                                            0.4: "0.4",
+                                                            0.6: "0.6",
+                                                            0.8: "0.8",
+                                                            1.0: "1.0"
+                                                        },
+                                                        value=[0,1], 
+                                                        id='e_slider'
+                                                    ),
+                                                    ],
+                                                title="Variables",
+                                            ),
+                                        ],
+                                        always_open=True, flush=True,
                                     )
-                                ],
-                                title="Test",
-                            ),
-                            dbc.AccordionItem(
-                                [
-                                    html.H2("Density"),
-                                    dcc.Checklist(
-                                        options={
-                                            "Loose":"Loose",
-                                            "Dense":"Dense"},
-                                        value=["Loose", "Dense"],
-                                        id="density_checklist",
-                                        inline=True
-                                    ),
-                                    html.H2("Plasticity"),
-                                    dcc.Checklist(
-                                        options={
-                                            "Plastic":"Plastic",
-                                            "Non-plastic":"Nonplastic",
-                                            "Unknown":"Unknown"},
-                                        value=["Plastic", "Non-plastic","Unknown"],
-                                        id="plasticity_checklist",
-                                        inline=True
-                                    ),
-                                    html.H2("PSD"),
-                                    dcc.Checklist(
-                                        options={
-                                            "Clay":"Clay",
-                                            "Sand":"Sand",
-                                            "Silt":"Silt"},
-                                        value=["Clay", "Sand","Silt"],
-                                        id="psd_checklist",
-                                        inline=True
-                                    ),
-                                ],
-                                title="Sample",
-                            ),
-                            dbc.AccordionItem(
-                                [
-                                    html.H2("Axial Strain Filter"),
-                                    html.P(id="axial_value"),
-                                    dcc.RangeSlider(
-                                        0,
-                                        0.5,
-                                        step=0.05,
-                                        marks={
-                                            0.0: "0.0",
-                                            0.1: "0.1",
-                                            0.2: "0.2",
-                                            0.3: "0.3",
-                                            0.4: "0.4",
-                                            0.5: "0.5"
-                                        },
-                                        value=[0,0.5], 
-                                        id='axial_slider'
-                                    ),
-                                    "Min Value:",
-                                    dcc.Input(id="axial_min_value", type="number", min=0, max=0.5, value=0.5, style={'width': '80px'}),
-                                    "Max Value:",
-                                    dcc.Input(id="axial_max_value", type="number", min=0, max=0.5, value=0, style={'width': '80px'}),
-                                    
-                                    html.H2("p' Filter"),
-                                    html.P(id="p_value"),
-                                    dcc.RangeSlider(
-                                        0,
-                                        500,
-                                        step=None,
-                                        value=[0,500], 
-                                        id='p_slider'
-                                    ), 
-                                    html.H2("Induced PWP Filter"),
-                                    html.P(id="pwp_value"),
-                                    dcc.RangeSlider(
-                                        0,
-                                        500,
-                                        step=None,
-                                        value=[0,500], 
-                                        id='pwp_slider'
-                                    ),
-                                    html.H2("Deviator stress (q) Filter"),
-                                    html.P(id="q_value"),
-                                    dcc.RangeSlider(
-                                        0,
-                                        500,
-                                        step=None,
-                                        value=[0,500], 
-                                        id='q_slider'
-                                    ),
-
-                                    html.H2("Void Ratio (e) Filter"),
-                                    html.P(id="e_value"),
-                                    dcc.RangeSlider(
-                                        0,
-                                        1,
-                                        step=0.01,
-                                        marks={
-                                            0.0: "0.0",
-                                            0.2: "0.2",
-                                            0.4: "0.4",
-                                            0.6: "0.6",
-                                            0.8: "0.8",
-                                            1.0: "1.0"
-                                        },
-                                        value=[0,1], 
-                                        id='e_slider'
-                                    ),
-                                    ],
-                                title="Variables",
-                            ),
-                        ],
-                        always_open=True, flush=True,
-                    )
-                ),
-                
-            ]
-        ), 
-        html.Div(
-            id = "dashboard",
-            children = [
-                dcc.Graph(id="axial_deviator_fig"),
-                dcc.Graph(id="axial_pwp_fig"), 
-                dcc.Graph(id="q_p_fig"),
-                dcc.Graph(id="axial_vol_fig"), 
-                dcc.Graph(id="e_logp_fig"),
-                dcc.Graph(id="stress_ratio_axial_fig")
+                                ),
+                                
+                            ]
+                        ), 
+                        width=3
+                    ),
+                    dbc.Col(
+                        html.Div(
+                            id = "dashboard",
+                            children = [
+                                dcc.Graph(id="axial_deviator_fig"),
+                                dcc.Graph(id="axial_pwp_fig"), 
+                                dcc.Graph(id="q_p_fig"),
+                                dcc.Graph(id="axial_vol_fig"), 
+                                dcc.Graph(id="e_logp_fig"),
+                                dcc.Graph(id="stress_ratio_axial_fig")
+                            ]
+                        ), width=9 
+                    ),
+                    ]
+                )
             ]
         )
-    ]
+    ],
+    fluid=True,
 )
 
 @app.callback(

--- a/main.js
+++ b/main.js
@@ -9,7 +9,7 @@ const path = require('node:path')
 
 //  Defines the path to the Python api file
 const API = './api/api'
-const DASH = './dash/page'
+const DASH = './api/page'
 const API_PORT = 18018
 const DASH_PORT = 18019
 


### PR DESCRIPTION
- Changed path in main.py from ./dash/page to ./api/page
- Added Bootstrap cols layout
- Fixed sidebar collapsing when closed
- Fixed (position of) sidebar while scrolling
- Added scrolling to sidebar div to see all filters when expanded
- Added tooltips to all sliders
-- Should we only show when on hover? Since the values are shown already in the input boxes below
- Rewrote callbacks into a function `sync_slider_callback` that can be reused for multiple sliders
